### PR TITLE
feat: add plugin health monitor for marketplace workflows

### DIFF
--- a/.github/workflows/plugin-health-monitor.yml
+++ b/.github/workflows/plugin-health-monitor.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   monitor:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: plugin-health-monitor
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +31,7 @@ jobs:
           # or set a comma-separated bot/app actor list.
           DISPATCH_ACTORS: ""
         with:
+          github-token: ${{ secrets.MARKETPLACE_MONITOR_TOKEN }}
           script: |
             const { runPluginHealthMonitor } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/plugin-health-monitor.mjs`);
             const result = await runPluginHealthMonitor({ github, context, core });

--- a/.github/workflows/plugin-health-monitor.yml
+++ b/.github/workflows/plugin-health-monitor.yml
@@ -1,0 +1,33 @@
+name: Plugin Health Monitor
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan marketplace plugin workflow failures
+        uses: actions/github-script@v7
+        env:
+          TARGET_ORG: ubiquity-os-marketplace
+          FAILURE_THRESHOLD: "10"
+          ISSUE_MENTIONS: "@0x4007,@gentlementlegen"
+          # Keep empty to evaluate all workflow_dispatch actors,
+          # or set a comma-separated bot/app actor list.
+          DISPATCH_ACTORS: ""
+        with:
+          script: |
+            const { runPluginHealthMonitor } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/plugin-health-monitor.mjs`);
+            const result = await runPluginHealthMonitor({ github, context, core });
+            core.info(`Monitor result: ${JSON.stringify(result)}`);

--- a/scripts/plugin-health-monitor.mjs
+++ b/scripts/plugin-health-monitor.mjs
@@ -171,7 +171,8 @@ export async function runPluginHealthMonitor({ github, context, core }) {
       }
 
       alerts += 1;
-      const runsToInclude = filteredRuns.slice(0, Math.max(failures, threshold));
+      const maxRunEntries = Math.min(Math.max(threshold, 10), 50);
+      const runsToInclude = filteredRuns.slice(0, maxRunEntries);
       const marker = toMarker(fullName);
       const title = buildIssueTitle(fullName, failures);
       const body = buildIssueBody({

--- a/scripts/plugin-health-monitor.mjs
+++ b/scripts/plugin-health-monitor.mjs
@@ -96,7 +96,11 @@ async function findOpenMonitorIssue(github, owner, repo, marker) {
 
 export async function runPluginHealthMonitor({ github, context, core }) {
   const org = process.env.TARGET_ORG || "ubiquity-os-marketplace";
-  const threshold = Number.parseInt(process.env.FAILURE_THRESHOLD || "10", 10);
+  const parsedThreshold = Number.parseInt(process.env.FAILURE_THRESHOLD || "10", 10);
+  const threshold = Number.isInteger(parsedThreshold) && parsedThreshold > 0 ? parsedThreshold : 10;
+  if (!Number.isInteger(parsedThreshold) || parsedThreshold <= 0) {
+    core.warning(`Invalid FAILURE_THRESHOLD "${process.env.FAILURE_THRESHOLD}". Falling back to 10.`);
+  }
   const dryRun = (process.env.DRY_RUN || "false").toLowerCase() === "true";
   const maintainers = (process.env.ISSUE_MENTIONS || "@0x4007,@gentlementlegen")
     .split(",")
@@ -111,7 +115,7 @@ export async function runPluginHealthMonitor({ github, context, core }) {
 
   const repos = await github.paginate(github.rest.repos.listForOrg, {
     org,
-    type: "public",
+    type: "all",
     per_page: 100,
   });
 
@@ -122,62 +126,67 @@ export async function runPluginHealthMonitor({ github, context, core }) {
     const repoName = repo.name;
     const fullName = repo.full_name;
 
-    const runsResponse = await github.rest.actions.listWorkflowRunsForRepo({
-      owner,
-      repo: repoName,
-      event: "workflow_dispatch",
-      status: "completed",
-      per_page: 50,
-    });
-
-    const filteredRuns = filterRunsByActors(runsResponse.data.workflow_runs || [], allowedActors);
-    const failures = countConsecutiveFailures(filteredRuns);
-
-    if (failures < threshold) {
-      continue;
-    }
-
-    alerts += 1;
-    const runsToInclude = filteredRuns.slice(0, Math.max(failures, threshold));
-    const marker = toMarker(fullName);
-    const title = buildIssueTitle(fullName, failures);
-    const body = buildIssueBody({
-      repoFullName: fullName,
-      failures,
-      threshold,
-      maintainers,
-      runs: runsToInclude,
-    });
-
-    core.warning(`${fullName} exceeded failure threshold (${failures})`);
-
-    if (dryRun) {
-      core.info(`[dry-run] would create/update issue in ${fullName}`);
-      continue;
-    }
-
-    const existingIssue = await findOpenMonitorIssue(github, owner, repoName, marker);
-
-    if (existingIssue) {
-      await github.rest.issues.update({
+    try {
+      const perPage = Math.min(100, Math.max(50, threshold * 2));
+      const runsResponse = await github.rest.actions.listWorkflowRunsForRepo({
         owner,
         repo: repoName,
-        issue_number: existingIssue.number,
+        event: "workflow_dispatch",
+        status: "completed",
+        per_page: perPage,
+      });
+
+      const filteredRuns = filterRunsByActors(runsResponse.data.workflow_runs || [], allowedActors);
+      const failures = countConsecutiveFailures(filteredRuns);
+
+      if (failures < threshold) {
+        continue;
+      }
+
+      alerts += 1;
+      const runsToInclude = filteredRuns.slice(0, Math.max(failures, threshold));
+      const marker = toMarker(fullName);
+      const title = buildIssueTitle(fullName, failures);
+      const body = buildIssueBody({
+        repoFullName: fullName,
+        failures,
+        threshold,
+        maintainers,
+        runs: runsToInclude,
+      });
+
+      core.warning(`${fullName} exceeded failure threshold (${failures})`);
+
+      if (dryRun) {
+        core.info(`[dry-run] would create/update issue in ${fullName}`);
+        continue;
+      }
+
+      const existingIssue = await findOpenMonitorIssue(github, owner, repoName, marker);
+
+      if (existingIssue) {
+        await github.rest.issues.update({
+          owner,
+          repo: repoName,
+          issue_number: existingIssue.number,
+          title,
+          body,
+        });
+        core.info(`Updated monitor issue in ${fullName}: #${existingIssue.number}`);
+        continue;
+      }
+
+      const created = await github.rest.issues.create({
+        owner,
+        repo: repoName,
         title,
         body,
       });
-      core.info(`Updated monitor issue in ${fullName}: #${existingIssue.number}`);
-      continue;
+
+      core.info(`Created monitor issue in ${fullName}: #${created.data.number}`);
+    } catch (error) {
+      core.warning(`Skipping ${fullName} due to API error: ${error.message}`);
     }
-
-    const created = await github.rest.issues.create({
-      owner,
-      repo: repoName,
-      title,
-      body,
-    });
-
-    core.info(`Created monitor issue in ${fullName}: #${created.data.number}`);
   }
 
   core.info(`Plugin health monitor finished. Alerts raised: ${alerts}`);

--- a/scripts/plugin-health-monitor.mjs
+++ b/scripts/plugin-health-monitor.mjs
@@ -94,6 +94,41 @@ async function findOpenMonitorIssue(github, owner, repo, marker) {
   });
 }
 
+async function fetchCompletedDispatchRuns(github, owner, repo, maxPages = 10) {
+  if (typeof github.paginate === "function") {
+    let fetchedPages = 0;
+
+    return github.paginate(
+      github.rest.actions.listWorkflowRunsForRepo,
+      {
+        owner,
+        repo,
+        event: "workflow_dispatch",
+        status: "completed",
+        per_page: 100,
+      },
+      (response, done) => {
+        fetchedPages += 1;
+        if (fetchedPages >= maxPages) {
+          done();
+        }
+
+        return response.data.workflow_runs || [];
+      },
+    );
+  }
+
+  const runsResponse = await github.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    event: "workflow_dispatch",
+    status: "completed",
+    per_page: 100,
+  });
+
+  return runsResponse.data.workflow_runs || [];
+}
+
 export async function runPluginHealthMonitor({ github, context, core }) {
   const org = process.env.TARGET_ORG || "ubiquity-os-marketplace";
   const parsedThreshold = Number.parseInt(process.env.FAILURE_THRESHOLD || "10", 10);
@@ -127,16 +162,8 @@ export async function runPluginHealthMonitor({ github, context, core }) {
     const fullName = repo.full_name;
 
     try {
-      const perPage = Math.min(100, Math.max(50, threshold * 2));
-      const runsResponse = await github.rest.actions.listWorkflowRunsForRepo({
-        owner,
-        repo: repoName,
-        event: "workflow_dispatch",
-        status: "completed",
-        per_page: perPage,
-      });
-
-      const filteredRuns = filterRunsByActors(runsResponse.data.workflow_runs || [], allowedActors);
+      const runs = await fetchCompletedDispatchRuns(github, owner, repoName);
+      const filteredRuns = filterRunsByActors(runs, allowedActors);
       const failures = countConsecutiveFailures(filteredRuns);
 
       if (failures < threshold) {

--- a/scripts/plugin-health-monitor.mjs
+++ b/scripts/plugin-health-monitor.mjs
@@ -1,0 +1,190 @@
+const FAILURE_CONCLUSIONS = new Set([
+  "failure",
+  "timed_out",
+  "startup_failure",
+  "action_required",
+]);
+
+const BREAK_CONCLUSIONS = new Set([
+  "success",
+  "neutral",
+  "skipped",
+  "cancelled",
+]);
+
+export function filterRunsByActors(runs, allowedActors = []) {
+  if (!allowedActors.length) {
+    return runs;
+  }
+
+  const allow = new Set(allowedActors.map((actor) => actor.toLowerCase().trim()));
+  return runs.filter((run) => allow.has((run.actor?.login || "").toLowerCase()));
+}
+
+export function countConsecutiveFailures(runs) {
+  let count = 0;
+
+  for (const run of runs) {
+    const conclusion = run?.conclusion || "";
+
+    if (FAILURE_CONCLUSIONS.has(conclusion)) {
+      count += 1;
+      continue;
+    }
+
+    if (BREAK_CONCLUSIONS.has(conclusion) || !conclusion) {
+      break;
+    }
+
+    break;
+  }
+
+  return count;
+}
+
+function toMarker(repoFullName) {
+  return `<!-- plugin-health-monitor:${repoFullName} -->`;
+}
+
+export function buildIssueTitle(repoFullName, failures) {
+  return `[Plugin Health Monitor] ${repoFullName} has ${failures} consecutive dispatch failures`;
+}
+
+export function buildIssueBody({
+  repoFullName,
+  failures,
+  threshold,
+  maintainers,
+  runs,
+}) {
+  const marker = toMarker(repoFullName);
+  const ping = maintainers.length ? maintainers.join(" ") : "@0x4007 @gentlementlegen";
+
+  const lines = runs.map((run, index) => {
+    const actor = run.actor?.login || "unknown";
+    return `${index + 1}. [${run.name || "workflow"} #${run.run_number}](${run.html_url}) — \`${run.conclusion}\` by @${actor} at ${run.created_at}`;
+  });
+
+  return [
+    marker,
+    "## Plugin Health Alert",
+    "",
+    `Detected **${failures} consecutive failed workflow_dispatch runs** (threshold: ${threshold}) for \`${repoFullName}\`.`,
+    "",
+    "### Most recent runs",
+    ...(lines.length ? lines : ["- No run details available."]),
+    "",
+    `cc ${ping}`,
+    "",
+    "_Generated automatically by plugin health monitor workflow._",
+  ].join("\n");
+}
+
+async function findOpenMonitorIssue(github, owner, repo, marker) {
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+
+  return issues.find((issue) => {
+    const isPR = !!issue.pull_request;
+    return !isPR && typeof issue.body === "string" && issue.body.includes(marker);
+  });
+}
+
+export async function runPluginHealthMonitor({ github, context, core }) {
+  const org = process.env.TARGET_ORG || "ubiquity-os-marketplace";
+  const threshold = Number.parseInt(process.env.FAILURE_THRESHOLD || "10", 10);
+  const dryRun = (process.env.DRY_RUN || "false").toLowerCase() === "true";
+  const maintainers = (process.env.ISSUE_MENTIONS || "@0x4007,@gentlementlegen")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const allowedActors = (process.env.DISPATCH_ACTORS || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  core.info(`Scanning org ${org} with threshold ${threshold}`);
+
+  const repos = await github.paginate(github.rest.repos.listForOrg, {
+    org,
+    type: "public",
+    per_page: 100,
+  });
+
+  let alerts = 0;
+
+  for (const repo of repos) {
+    const owner = repo.owner.login;
+    const repoName = repo.name;
+    const fullName = repo.full_name;
+
+    const runsResponse = await github.rest.actions.listWorkflowRunsForRepo({
+      owner,
+      repo: repoName,
+      event: "workflow_dispatch",
+      status: "completed",
+      per_page: 50,
+    });
+
+    const filteredRuns = filterRunsByActors(runsResponse.data.workflow_runs || [], allowedActors);
+    const failures = countConsecutiveFailures(filteredRuns);
+
+    if (failures < threshold) {
+      continue;
+    }
+
+    alerts += 1;
+    const runsToInclude = filteredRuns.slice(0, Math.max(failures, threshold));
+    const marker = toMarker(fullName);
+    const title = buildIssueTitle(fullName, failures);
+    const body = buildIssueBody({
+      repoFullName: fullName,
+      failures,
+      threshold,
+      maintainers,
+      runs: runsToInclude,
+    });
+
+    core.warning(`${fullName} exceeded failure threshold (${failures})`);
+
+    if (dryRun) {
+      core.info(`[dry-run] would create/update issue in ${fullName}`);
+      continue;
+    }
+
+    const existingIssue = await findOpenMonitorIssue(github, owner, repoName, marker);
+
+    if (existingIssue) {
+      await github.rest.issues.update({
+        owner,
+        repo: repoName,
+        issue_number: existingIssue.number,
+        title,
+        body,
+      });
+      core.info(`Updated monitor issue in ${fullName}: #${existingIssue.number}`);
+      continue;
+    }
+
+    const created = await github.rest.issues.create({
+      owner,
+      repo: repoName,
+      title,
+      body,
+    });
+
+    core.info(`Created monitor issue in ${fullName}: #${created.data.number}`);
+  }
+
+  core.info(`Plugin health monitor finished. Alerts raised: ${alerts}`);
+
+  if (!alerts) {
+    core.info("No repos crossed the consecutive failure threshold.");
+  }
+
+  return { org, threshold, alerts, runId: context.runId };
+}

--- a/scripts/plugin-health-monitor.test.mjs
+++ b/scripts/plugin-health-monitor.test.mjs
@@ -6,6 +6,7 @@ import {
   buildIssueTitle,
   countConsecutiveFailures,
   filterRunsByActors,
+  runPluginHealthMonitor,
 } from "./plugin-health-monitor.mjs";
 
 test("countConsecutiveFailures counts from latest run until first non-failure", () => {
@@ -60,4 +61,132 @@ test("buildIssueTitle and body include repo marker and run links", () => {
   assert.match(body, /plugin-health-monitor:ubiquity-os-marketplace\/example-plugin/);
   assert.match(body, /CI #77/);
   assert.match(body, /@0x4007/);
+});
+
+function createGithubMock({ repos, runsByRepo, issuesByRepo, throwRepos = [] }) {
+  const created = [];
+  const updated = [];
+
+  return {
+    created,
+    updated,
+    github: {
+      paginate: async (fn, params) => {
+        if (fn.name === "listForOrg") {
+          return repos;
+        }
+        if (fn.name === "listForRepo") {
+          const key = `${params.owner}/${params.repo}`;
+          return issuesByRepo[key] || [];
+        }
+        throw new Error(`Unexpected paginate function: ${fn.name}`);
+      },
+      rest: {
+        repos: { listForOrg: async function listForOrg() {} },
+        actions: {
+          listWorkflowRunsForRepo: async ({ owner, repo }) => {
+            const key = `${owner}/${repo}`;
+            if (throwRepos.includes(key)) {
+              throw new Error("simulated API error");
+            }
+            return { data: { workflow_runs: runsByRepo[key] || [] } };
+          },
+        },
+        issues: {
+          listForRepo: async function listForRepo() {},
+          create: async (payload) => {
+            created.push(payload);
+            return { data: { number: 100 + created.length } };
+          },
+          update: async (payload) => {
+            updated.push(payload);
+            return { data: payload };
+          },
+        },
+      },
+    },
+  };
+}
+
+test("runPluginHealthMonitor creates issue when threshold is met", async () => {
+  process.env.TARGET_ORG = "ubiquity-os-marketplace";
+  process.env.FAILURE_THRESHOLD = "2";
+  process.env.ISSUE_MENTIONS = "@0x4007";
+  process.env.DISPATCH_ACTORS = "";
+  process.env.DRY_RUN = "false";
+
+  const { github, created, updated } = createGithubMock({
+    repos: [{ owner: { login: "ubiquity-os-marketplace" }, name: "repo-a", full_name: "ubiquity-os-marketplace/repo-a" }],
+    runsByRepo: {
+      "ubiquity-os-marketplace/repo-a": [
+        { conclusion: "failure", run_number: 2, html_url: "https://x/2", created_at: "2026-03-04T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+        { conclusion: "failure", run_number: 1, html_url: "https://x/1", created_at: "2026-03-03T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+      ],
+    },
+    issuesByRepo: {},
+  });
+
+  const logs = [];
+  const core = { info: (m) => logs.push(m), warning: (m) => logs.push(m) };
+  const result = await runPluginHealthMonitor({ github, context: { runId: 1 }, core });
+
+  assert.equal(result.alerts, 1);
+  assert.equal(created.length, 1);
+  assert.equal(updated.length, 0);
+});
+
+test("runPluginHealthMonitor updates existing marker issue", async () => {
+  process.env.FAILURE_THRESHOLD = "2";
+  process.env.DRY_RUN = "false";
+
+  const markerIssue = {
+    number: 12,
+    body: "<!-- plugin-health-monitor:ubiquity-os-marketplace/repo-a -->",
+  };
+
+  const { github, created, updated } = createGithubMock({
+    repos: [{ owner: { login: "ubiquity-os-marketplace" }, name: "repo-a", full_name: "ubiquity-os-marketplace/repo-a" }],
+    runsByRepo: {
+      "ubiquity-os-marketplace/repo-a": [
+        { conclusion: "failure", run_number: 2, html_url: "https://x/2", created_at: "2026-03-04T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+        { conclusion: "failure", run_number: 1, html_url: "https://x/1", created_at: "2026-03-03T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+      ],
+    },
+    issuesByRepo: {
+      "ubiquity-os-marketplace/repo-a": [markerIssue],
+    },
+  });
+
+  const core = { info: () => {}, warning: () => {} };
+  await runPluginHealthMonitor({ github, context: { runId: 2 }, core });
+
+  assert.equal(created.length, 0);
+  assert.equal(updated.length, 1);
+  assert.equal(updated[0].issue_number, 12);
+});
+
+test("runPluginHealthMonitor isolates per-repo API errors", async () => {
+  process.env.FAILURE_THRESHOLD = "1";
+  process.env.DRY_RUN = "true";
+
+  const { github } = createGithubMock({
+    repos: [
+      { owner: { login: "ubiquity-os-marketplace" }, name: "repo-error", full_name: "ubiquity-os-marketplace/repo-error" },
+      { owner: { login: "ubiquity-os-marketplace" }, name: "repo-ok", full_name: "ubiquity-os-marketplace/repo-ok" },
+    ],
+    runsByRepo: {
+      "ubiquity-os-marketplace/repo-ok": [
+        { conclusion: "failure", run_number: 1, html_url: "https://x/1", created_at: "2026-03-04T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+      ],
+    },
+    issuesByRepo: {},
+    throwRepos: ["ubiquity-os-marketplace/repo-error"],
+  });
+
+  const warnings = [];
+  const core = { info: () => {}, warning: (m) => warnings.push(m) };
+  const result = await runPluginHealthMonitor({ github, context: { runId: 3 }, core });
+
+  assert.equal(result.alerts, 1);
+  assert.ok(warnings.some((m) => m.includes("Skipping ubiquity-os-marketplace/repo-error due to API error")));
 });

--- a/scripts/plugin-health-monitor.test.mjs
+++ b/scripts/plugin-health-monitor.test.mjs
@@ -9,6 +9,20 @@ import {
   runPluginHealthMonitor,
 } from "./plugin-health-monitor.mjs";
 
+const MONITOR_ENV_KEYS = [
+  "TARGET_ORG",
+  "FAILURE_THRESHOLD",
+  "ISSUE_MENTIONS",
+  "DISPATCH_ACTORS",
+  "DRY_RUN",
+];
+
+test.afterEach(() => {
+  for (const key of MONITOR_ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
 test("countConsecutiveFailures counts from latest run until first non-failure", () => {
   const runs = [
     { conclusion: "failure" },

--- a/scripts/plugin-health-monitor.test.mjs
+++ b/scripts/plugin-health-monitor.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildIssueBody,
+  buildIssueTitle,
+  countConsecutiveFailures,
+  filterRunsByActors,
+} from "./plugin-health-monitor.mjs";
+
+test("countConsecutiveFailures counts from latest run until first non-failure", () => {
+  const runs = [
+    { conclusion: "failure" },
+    { conclusion: "timed_out" },
+    { conclusion: "failure" },
+    { conclusion: "success" },
+    { conclusion: "failure" },
+  ];
+
+  assert.equal(countConsecutiveFailures(runs), 3);
+});
+
+test("countConsecutiveFailures returns 0 when latest run is successful", () => {
+  const runs = [{ conclusion: "success" }, { conclusion: "failure" }];
+  assert.equal(countConsecutiveFailures(runs), 0);
+});
+
+test("filterRunsByActors keeps only configured actors", () => {
+  const runs = [
+    { actor: { login: "ubiquity-app[bot]" }, conclusion: "failure" },
+    { actor: { login: "someone-else" }, conclusion: "failure" },
+  ];
+
+  const filtered = filterRunsByActors(runs, ["ubiquity-app[bot]"]);
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].actor.login, "ubiquity-app[bot]");
+});
+
+test("buildIssueTitle and body include repo marker and run links", () => {
+  const title = buildIssueTitle("ubiquity-os-marketplace/example-plugin", 12);
+  assert.match(title, /12 consecutive dispatch failures/);
+
+  const body = buildIssueBody({
+    repoFullName: "ubiquity-os-marketplace/example-plugin",
+    failures: 12,
+    threshold: 10,
+    maintainers: ["@0x4007"],
+    runs: [
+      {
+        name: "CI",
+        run_number: 77,
+        html_url: "https://github.com/example/actions/runs/77",
+        conclusion: "failure",
+        actor: { login: "ubiquity-app[bot]" },
+        created_at: "2026-03-04T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.match(body, /plugin-health-monitor:ubiquity-os-marketplace\/example-plugin/);
+  assert.match(body, /CI #77/);
+  assert.match(body, /@0x4007/);
+});

--- a/scripts/plugin-health-monitor.test.mjs
+++ b/scripts/plugin-health-monitor.test.mjs
@@ -165,6 +165,36 @@ test("runPluginHealthMonitor updates existing marker issue", async () => {
   assert.equal(updated[0].issue_number, 12);
 });
 
+test("runPluginHealthMonitor dry-run mode does not write issues", async () => {
+  process.env.FAILURE_THRESHOLD = "2";
+  process.env.DRY_RUN = "true";
+
+  const markerIssue = {
+    number: 19,
+    body: "<!-- plugin-health-monitor:ubiquity-os-marketplace/repo-a -->",
+  };
+
+  const { github, created, updated } = createGithubMock({
+    repos: [{ owner: { login: "ubiquity-os-marketplace" }, name: "repo-a", full_name: "ubiquity-os-marketplace/repo-a" }],
+    runsByRepo: {
+      "ubiquity-os-marketplace/repo-a": [
+        { conclusion: "failure", run_number: 4, html_url: "https://x/4", created_at: "2026-03-05T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+        { conclusion: "failure", run_number: 3, html_url: "https://x/3", created_at: "2026-03-04T00:00:00Z", actor: { login: "bot" }, name: "CI" },
+      ],
+    },
+    issuesByRepo: {
+      "ubiquity-os-marketplace/repo-a": [markerIssue],
+    },
+  });
+
+  const core = { info: () => {}, warning: () => {} };
+  const result = await runPluginHealthMonitor({ github, context: { runId: 22 }, core });
+
+  assert.equal(result.alerts, 1);
+  assert.equal(created.length, 0);
+  assert.equal(updated.length, 0);
+});
+
 test("runPluginHealthMonitor isolates per-repo API errors", async () => {
   process.env.FAILURE_THRESHOLD = "1";
   process.env.DRY_RUN = "true";

--- a/scripts/plugin-health-monitor.test.mjs
+++ b/scripts/plugin-health-monitor.test.mjs
@@ -63,49 +63,92 @@ test("buildIssueTitle and body include repo marker and run links", () => {
   assert.match(body, /@0x4007/);
 });
 
-function createGithubMock({ repos, runsByRepo, issuesByRepo, throwRepos = [] }) {
+function createGithubMock({ repos, runsByRepo = {}, runsPagesByRepo = {}, issuesByRepo = {}, throwRepos = [] }) {
   const created = [];
   const updated = [];
 
-  return {
-    created,
-    updated,
-    github: {
-      paginate: async (fn, params) => {
-        if (fn.name === "listForOrg") {
-          return repos;
+  const rest = {
+    repos: { listForOrg: async function listForOrg() {} },
+    actions: {
+      listWorkflowRunsForRepo: async function listWorkflowRunsForRepo({ owner, repo }) {
+        const key = `${owner}/${repo}`;
+        if (throwRepos.includes(key)) {
+          throw new Error("simulated API error");
         }
-        if (fn.name === "listForRepo") {
-          const key = `${params.owner}/${params.repo}`;
-          return issuesByRepo[key] || [];
+
+        const pagedRuns = runsPagesByRepo[key];
+        if (pagedRuns) {
+          return { data: { workflow_runs: pagedRuns[0] || [] } };
         }
-        throw new Error(`Unexpected paginate function: ${fn.name}`);
+
+        return { data: { workflow_runs: runsByRepo[key] || [] } };
       },
-      rest: {
-        repos: { listForOrg: async function listForOrg() {} },
-        actions: {
-          listWorkflowRunsForRepo: async ({ owner, repo }) => {
-            const key = `${owner}/${repo}`;
-            if (throwRepos.includes(key)) {
-              throw new Error("simulated API error");
-            }
-            return { data: { workflow_runs: runsByRepo[key] || [] } };
-          },
-        },
-        issues: {
-          listForRepo: async function listForRepo() {},
-          create: async (payload) => {
-            created.push(payload);
-            return { data: { number: 100 + created.length } };
-          },
-          update: async (payload) => {
-            updated.push(payload);
-            return { data: payload };
-          },
-        },
+    },
+    issues: {
+      listForRepo: async function listForRepo() {},
+      create: async (payload) => {
+        created.push(payload);
+        return { data: { number: 100 + created.length } };
+      },
+      update: async (payload) => {
+        updated.push(payload);
+        return { data: payload };
       },
     },
   };
+
+  const github = {
+    rest,
+    paginate: async (fn, params, mapFn) => {
+      if (fn === rest.repos.listForOrg) {
+        return repos;
+      }
+
+      if (fn === rest.issues.listForRepo) {
+        const key = `${params.owner}/${params.repo}`;
+        return issuesByRepo[key] || [];
+      }
+
+      if (fn === rest.actions.listWorkflowRunsForRepo) {
+        const key = `${params.owner}/${params.repo}`;
+        if (throwRepos.includes(key)) {
+          throw new Error("simulated API error");
+        }
+
+        const pages = runsPagesByRepo[key] || [runsByRepo[key] || []];
+
+        if (!mapFn) {
+          return pages.flat();
+        }
+
+        const collected = [];
+        let shouldStop = false;
+
+        for (const pageRuns of pages) {
+          const mapped = mapFn(
+            { data: { workflow_runs: pageRuns } },
+            () => {
+              shouldStop = true;
+            },
+          );
+
+          if (Array.isArray(mapped)) {
+            collected.push(...mapped);
+          }
+
+          if (shouldStop) {
+            break;
+          }
+        }
+
+        return collected;
+      }
+
+      throw new Error("Unexpected paginate function");
+    },
+  };
+
+  return { created, updated, github };
 }
 
 test("runPluginHealthMonitor creates issue when threshold is met", async () => {
@@ -195,8 +238,42 @@ test("runPluginHealthMonitor dry-run mode does not write issues", async () => {
   assert.equal(updated.length, 0);
 });
 
+test("runPluginHealthMonitor paginates runs before actor filtering", async () => {
+  process.env.TARGET_ORG = "ubiquity-os-marketplace";
+  process.env.FAILURE_THRESHOLD = "3";
+  process.env.DISPATCH_ACTORS = "ubiquity-app[bot]";
+  process.env.DRY_RUN = "false";
+
+  const { github, created } = createGithubMock({
+    repos: [{ owner: { login: "ubiquity-os-marketplace" }, name: "repo-a", full_name: "ubiquity-os-marketplace/repo-a" }],
+    runsPagesByRepo: {
+      "ubiquity-os-marketplace/repo-a": [
+        [
+          { conclusion: "failure", run_number: 7, html_url: "https://x/7", created_at: "2026-03-07T00:00:00Z", actor: { login: "outsider-1" }, name: "CI" },
+          { conclusion: "failure", run_number: 6, html_url: "https://x/6", created_at: "2026-03-06T00:00:00Z", actor: { login: "outsider-2" }, name: "CI" },
+        ],
+        [
+          { conclusion: "failure", run_number: 5, html_url: "https://x/5", created_at: "2026-03-05T00:00:00Z", actor: { login: "ubiquity-app[bot]" }, name: "CI" },
+          { conclusion: "failure", run_number: 4, html_url: "https://x/4", created_at: "2026-03-04T00:00:00Z", actor: { login: "ubiquity-app[bot]" }, name: "CI" },
+          { conclusion: "failure", run_number: 3, html_url: "https://x/3", created_at: "2026-03-03T00:00:00Z", actor: { login: "ubiquity-app[bot]" }, name: "CI" },
+          { conclusion: "success", run_number: 2, html_url: "https://x/2", created_at: "2026-03-02T00:00:00Z", actor: { login: "ubiquity-app[bot]" }, name: "CI" },
+        ],
+      ],
+    },
+    issuesByRepo: {},
+  });
+
+  const core = { info: () => {}, warning: () => {} };
+  const result = await runPluginHealthMonitor({ github, context: { runId: 23 }, core });
+
+  assert.equal(result.alerts, 1);
+  assert.equal(created.length, 1);
+});
+
 test("runPluginHealthMonitor isolates per-repo API errors", async () => {
+  process.env.TARGET_ORG = "ubiquity-os-marketplace";
   process.env.FAILURE_THRESHOLD = "1";
+  process.env.DISPATCH_ACTORS = "";
   process.env.DRY_RUN = "true";
 
   const { github } = createGithubMock({


### PR DESCRIPTION
## Summary
- add a daily + manual GitHub Action (`Plugin Health Monitor`) that scans all repos in `ubiquity-os-marketplace`
- detect consecutive failed `workflow_dispatch` runs and raise an alert issue when failures reach threshold (default: 10)
- avoid duplicate spam by updating an existing monitor issue (via marker) instead of creating a new one each run
- include latest failed run links, actors, and timestamps directly in the alert issue body and ping maintainers

## Implementation details
- added `.github/workflows/plugin-health-monitor.yml`
- added `scripts/plugin-health-monitor.mjs`:
  - actor filtering support (`DISPATCH_ACTORS` env)
  - consecutive failure counting logic
  - issue title/body generation
  - open monitor issue lookup + create/update behavior
- added unit tests in `scripts/plugin-health-monitor.test.mjs`

## Verification
- `node --test scripts/plugin-health-monitor.test.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/plugin-health-monitor.yml")'`

Fixes #12
