### PR TITLE
feat: add plugin health monitor for marketplace workflows

### DIFF
--- a/.github/workflows/plugin-health-monitor.yml
+++ b/.github/workflows/plugin-health-monitor.yml
@@ -16,6 +16,7 @@ on:
         default: 10
 
 permissions:
+  contents: read
   issues: write
   actions: read
 

--- a/.github/workflows/plugin-health-monitor.yml
+++ b/.github/workflows/plugin-health-monitor.yml
@@ -1,0 +1,46 @@
+name: Plugin Health Monitor
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only log findings, do not create/update issues"
+        type: boolean
+        default: false
+      failure_threshold:
+        description: "Consecutive failures before alerting (default: 10)"
+        type: number
+        default: 10
+
+permissions:
+  issues: write
+  actions: read
+
+jobs:
+  monitor:
+    name: Check Plugin Health
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run Plugin Health Monitor
+        uses: actions/github-script@v7
+        env:
+          TARGET_ORG: ubiquity-os-marketplace
+          FAILURE_THRESHOLD: ${{ inputs.failure_threshold || '10' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          ISSUE_MENTIONS: "@0x4007 @gentlementlegen"
+        with:
+          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          script: |
+            const { runPluginHealthMonitor } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/plugin-health-monitor.mjs`
+            );
+            await runPluginHealthMonitor({ github, context, core });

--- a/scripts/plugin-health-monitor.mjs
+++ b/scripts/plugin-health-monitor.mjs
@@ -1,0 +1,264 @@
+// @ts-check
+
+/**
+ * Plugin Health Monitor for UbiquityOS Marketplace
+ *
+ * Scans all repos in @ubiquity-os-marketplace for consecutive
+ * workflow_dispatch failures. Creates/updates alert issues when
+ * failures exceed threshold.
+ *
+ * Fixes over PR #18:
+ * - Uses CROSS_REPO_TOKEN for cross-repo issue creation
+ * - Validates FAILURE_THRESHOLD (guards against NaN)
+ * - Truncates issue body to stay under GitHub's 65536 char limit
+ * - Isolates env in tests (no shared mutation)
+ */
+
+const ISSUE_TITLE_PREFIX = "🚨 Plugin Health Alert:";
+const MAX_ISSUE_BODY_LENGTH = 60000; // GitHub limit is 65536, leave margin
+const DISPATCH_EVENT = "workflow_dispatch";
+
+/**
+ * @param {object} params
+ * @param {import("@octokit/rest").Octokit} params.github
+ * @param {object} params.context
+ * @param {object} params.core
+ */
+export async function runPluginHealthMonitor({ github, context, core }) {
+  const targetOrg = process.env.TARGET_ORG || "ubiquity-os-marketplace";
+  const threshold = parseThreshold(process.env.FAILURE_THRESHOLD);
+  const isDryRun = process.env.DRY_RUN === "true";
+  const mentions = process.env.ISSUE_MENTIONS || "@0x4007 @gentlementlegen";
+
+  core.info(`Monitoring org: ${targetOrg}`);
+  core.info(`Failure threshold: ${threshold}`);
+  core.info(`Dry run: ${isDryRun}`);
+
+  const repos = await listOrgRepos(github, targetOrg);
+  core.info(`Found ${repos.length} repositories`);
+
+  const alerts = [];
+
+  for (const repo of repos) {
+    const failures = await getConsecutiveFailures(github, targetOrg, repo.name);
+
+    if (failures.count >= threshold) {
+      core.warning(
+        `${repo.name}: ${failures.count} consecutive failures (threshold: ${threshold})`
+      );
+      alerts.push({ repo: repo.name, ...failures });
+    } else if (failures.count > 0) {
+      core.info(`${repo.name}: ${failures.count} failures (below threshold)`);
+    }
+  }
+
+  if (alerts.length === 0) {
+    core.info("All plugins healthy. No alerts.");
+    return { alerts: [], issues: [] };
+  }
+
+  core.warning(`${alerts.length} plugin(s) exceeded failure threshold`);
+
+  if (isDryRun) {
+    core.info("DRY RUN — skipping issue creation");
+    return { alerts, issues: [] };
+  }
+
+  const issues = [];
+  for (const alert of alerts) {
+    const issue = await createOrUpdateAlertIssue(
+      github,
+      targetOrg,
+      alert,
+      mentions
+    );
+    issues.push(issue);
+    core.info(`Alert issue: ${issue.html_url}`);
+  }
+
+  return { alerts, issues };
+}
+
+/**
+ * Parse and validate the failure threshold.
+ * @param {string|undefined} raw
+ * @returns {number}
+ */
+export function parseThreshold(raw) {
+  const parsed = Number.parseInt(raw || "10", 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 10; // safe default
+  }
+  return parsed;
+}
+
+/**
+ * List all non-archived repos in the target org.
+ */
+export async function listOrgRepos(github, org) {
+  const repos = [];
+  for await (const response of github.paginate.iterator(
+    github.rest.repos.listForOrg,
+    { org, type: "public", per_page: 100 }
+  )) {
+    for (const repo of response.data) {
+      if (!repo.archived && !repo.disabled) {
+        repos.push(repo);
+      }
+    }
+  }
+  return repos;
+}
+
+/**
+ * Get consecutive workflow_dispatch failures for a repo.
+ * Looks at the most recent workflow runs triggered by `workflow_dispatch`.
+ */
+export async function getConsecutiveFailures(github, org, repoName) {
+  let runs;
+  try {
+    const response = await github.rest.actions.listWorkflowRunsForRepo({
+      owner: org,
+      repo: repoName,
+      event: DISPATCH_EVENT,
+      per_page: 30,
+      status: "completed",
+    });
+    runs = response.data.workflow_runs;
+  } catch (error) {
+    // Repo may have no workflows
+    return { count: 0, runs: [] };
+  }
+
+  if (!runs || runs.length === 0) {
+    return { count: 0, runs: [] };
+  }
+
+  // Sort by created_at descending (most recent first)
+  runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+  // Count consecutive failures from the most recent run
+  let count = 0;
+  const failedRuns = [];
+
+  for (const run of runs) {
+    if (run.conclusion === "failure") {
+      count++;
+      failedRuns.push({
+        id: run.id,
+        name: run.name,
+        url: run.html_url,
+        created_at: run.created_at,
+        head_sha: run.head_sha?.substring(0, 7),
+      });
+    } else {
+      break; // Streak broken by a success
+    }
+  }
+
+  return { count, runs: failedRuns };
+}
+
+/**
+ * Create or update an alert issue in the failing repo.
+ */
+export async function createOrUpdateAlertIssue(
+  github,
+  org,
+  alert,
+  mentions
+) {
+  const title = `${ISSUE_TITLE_PREFIX} ${alert.repo}`;
+
+  // Check for existing open alert issue
+  const existing = await findExistingAlertIssue(github, org, alert.repo, title);
+
+  const body = buildIssueBody(alert, mentions);
+
+  if (existing) {
+    // Update existing issue
+    const updated = await github.rest.issues.update({
+      owner: org,
+      repo: alert.repo,
+      issue_number: existing.number,
+      body,
+    });
+    return updated.data;
+  }
+
+  // Create new issue
+  const created = await github.rest.issues.create({
+    owner: org,
+    repo: alert.repo,
+    title,
+    body,
+    labels: ["health-alert"],
+  });
+  return created.data;
+}
+
+/**
+ * Find existing open alert issue by title prefix.
+ */
+async function findExistingAlertIssue(github, org, repoName, title) {
+  try {
+    const { data: issues } = await github.rest.issues.listForRepo({
+      owner: org,
+      repo: repoName,
+      state: "open",
+      per_page: 50,
+    });
+    return issues.find((i) => i.title === title) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the alert issue body with failure details.
+ * Truncates to stay under GitHub's 65536 char limit.
+ */
+export function buildIssueBody(alert, mentions) {
+  const lines = [
+    `## 🚨 Plugin Health Alert`,
+    "",
+    `**Repository:** \`${alert.repo}\``,
+    `**Consecutive failures:** ${alert.count}`,
+    `**Last checked:** ${new Date().toISOString()}`,
+    "",
+    `cc ${mentions}`,
+    "",
+    "### Recent Failed Runs",
+    "",
+    "| # | Workflow | Date | SHA | Link |",
+    "|---|---------|------|-----|------|",
+  ];
+
+  for (let i = 0; i < alert.runs.length; i++) {
+    const run = alert.runs[i];
+    lines.push(
+      `| ${i + 1} | ${run.name || "N/A"} | ${run.created_at} | \`${run.head_sha || "N/A"}\` | [View](${run.url}) |`
+    );
+  }
+
+  lines.push(
+    "",
+    "---",
+    "",
+    "> This issue was automatically created by the [Plugin Health Monitor]" +
+      "(../.github/workflows/plugin-health-monitor.yml). " +
+      "It will be updated on subsequent runs if the plugin continues to fail. " +
+      "Close this issue once the problem is resolved."
+  );
+
+  let body = lines.join("\n");
+
+  // Truncate if too long (GitHub limit: 65536 chars)
+  if (body.length > MAX_ISSUE_BODY_LENGTH) {
+    body =
+      body.substring(0, MAX_ISSUE_BODY_LENGTH) +
+      "\n\n⚠️ _Output truncated. See workflow run for full details._";
+  }
+
+  return body;
+}

--- a/scripts/plugin-health-monitor.test.mjs
+++ b/scripts/plugin-health-monitor.test.mjs
@@ -1,0 +1,290 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseThreshold,
+  buildIssueBody,
+  getConsecutiveFailures,
+  runPluginHealthMonitor,
+} from "./plugin-health-monitor.mjs";
+
+// ─── parseThreshold ──────────────────────────────────────────
+
+describe("parseThreshold", () => {
+  it("parses valid integer", () => {
+    assert.equal(parseThreshold("5"), 5);
+    assert.equal(parseThreshold("20"), 20);
+  });
+
+  it("defaults to 10 for undefined", () => {
+    assert.equal(parseThreshold(undefined), 10);
+  });
+
+  it("defaults to 10 for empty string", () => {
+    assert.equal(parseThreshold(""), 10);
+  });
+
+  it("defaults to 10 for NaN input", () => {
+    assert.equal(parseThreshold("abc"), 10);
+  });
+
+  it("defaults to 10 for zero", () => {
+    assert.equal(parseThreshold("0"), 10);
+  });
+
+  it("defaults to 10 for negative", () => {
+    assert.equal(parseThreshold("-5"), 10);
+  });
+
+  it("defaults to 10 for Infinity string", () => {
+    assert.equal(parseThreshold("Infinity"), 10);
+  });
+});
+
+// ─── buildIssueBody ──────────────────────────────────────────
+
+describe("buildIssueBody", () => {
+  const mockAlert = {
+    repo: "test-plugin",
+    count: 12,
+    runs: [
+      {
+        id: 1,
+        name: "CI",
+        url: "https://github.com/org/repo/actions/runs/1",
+        created_at: "2026-03-28T00:00:00Z",
+        head_sha: "abc1234",
+      },
+      {
+        id: 2,
+        name: "CI",
+        url: "https://github.com/org/repo/actions/runs/2",
+        created_at: "2026-03-27T00:00:00Z",
+        head_sha: "def5678",
+      },
+    ],
+  };
+
+  it("includes repo name", () => {
+    const body = buildIssueBody(mockAlert, "@user1");
+    assert.ok(body.includes("`test-plugin`"));
+  });
+
+  it("includes failure count", () => {
+    const body = buildIssueBody(mockAlert, "@user1");
+    assert.ok(body.includes("12"));
+  });
+
+  it("includes mentions", () => {
+    const body = buildIssueBody(mockAlert, "@0x4007 @gentlementlegen");
+    assert.ok(body.includes("@0x4007"));
+    assert.ok(body.includes("@gentlementlegen"));
+  });
+
+  it("includes run links in table", () => {
+    const body = buildIssueBody(mockAlert, "@user1");
+    assert.ok(body.includes("[View](https://github.com/org/repo/actions/runs/1)"));
+  });
+
+  it("includes commit SHAs", () => {
+    const body = buildIssueBody(mockAlert, "@user1");
+    assert.ok(body.includes("`abc1234`"));
+  });
+
+  it("truncates body exceeding max length", () => {
+    const longAlert = {
+      repo: "test-plugin",
+      count: 1000,
+      runs: Array.from({ length: 500 }, (_, i) => ({
+        id: i,
+        name: "CI-" + "x".repeat(200),
+        url: "https://github.com/org/repo/actions/runs/" + i,
+        created_at: "2026-03-28T00:00:00Z",
+        head_sha: "abc1234",
+      })),
+    };
+    const body = buildIssueBody(longAlert, "@user1");
+    assert.ok(body.length <= 65536);
+    assert.ok(body.includes("truncated"));
+  });
+});
+
+// ─── getConsecutiveFailures ──────────────────────────────────
+
+describe("getConsecutiveFailures", () => {
+  it("returns 0 for empty runs", async () => {
+    const mockGithub = {
+      rest: {
+        actions: {
+          listWorkflowRunsForRepo: async () => ({
+            data: { workflow_runs: [] },
+          }),
+        },
+      },
+    };
+    const result = await getConsecutiveFailures(mockGithub, "org", "repo");
+    assert.equal(result.count, 0);
+  });
+
+  it("counts consecutive failures from most recent", async () => {
+    const mockGithub = {
+      rest: {
+        actions: {
+          listWorkflowRunsForRepo: async () => ({
+            data: {
+              workflow_runs: [
+                { conclusion: "failure", created_at: "2026-03-28T03:00:00Z", html_url: "u1", id: 1, name: "CI" },
+                { conclusion: "failure", created_at: "2026-03-28T02:00:00Z", html_url: "u2", id: 2, name: "CI" },
+                { conclusion: "failure", created_at: "2026-03-28T01:00:00Z", html_url: "u3", id: 3, name: "CI" },
+                { conclusion: "success", created_at: "2026-03-27T12:00:00Z", html_url: "u4", id: 4, name: "CI" },
+                { conclusion: "failure", created_at: "2026-03-27T06:00:00Z", html_url: "u5", id: 5, name: "CI" },
+              ],
+            },
+          }),
+        },
+      },
+    };
+    const result = await getConsecutiveFailures(mockGithub, "org", "repo");
+    assert.equal(result.count, 3); // Streak of 3, broken by success
+    assert.equal(result.runs.length, 3);
+  });
+
+  it("returns 0 when most recent is success", async () => {
+    const mockGithub = {
+      rest: {
+        actions: {
+          listWorkflowRunsForRepo: async () => ({
+            data: {
+              workflow_runs: [
+                { conclusion: "success", created_at: "2026-03-28T03:00:00Z", html_url: "u1", id: 1, name: "CI" },
+                { conclusion: "failure", created_at: "2026-03-28T02:00:00Z", html_url: "u2", id: 2, name: "CI" },
+              ],
+            },
+          }),
+        },
+      },
+    };
+    const result = await getConsecutiveFailures(mockGithub, "org", "repo");
+    assert.equal(result.count, 0);
+  });
+
+  it("handles API errors gracefully", async () => {
+    const mockGithub = {
+      rest: {
+        actions: {
+          listWorkflowRunsForRepo: async () => {
+            throw new Error("Not Found");
+          },
+        },
+      },
+    };
+    const result = await getConsecutiveFailures(mockGithub, "org", "repo");
+    assert.equal(result.count, 0);
+  });
+});
+
+// ─── runPluginHealthMonitor (integration) ────────────────────
+
+describe("runPluginHealthMonitor", () => {
+  let savedEnv;
+
+  beforeEach(() => {
+    // Isolate env — no shared mutation (fixes PR #18 test issue)
+    savedEnv = { ...process.env };
+  });
+
+  // Restore env after each test (node:test doesn't have afterEach in older versions)
+  function withCleanEnv(fn) {
+    return async () => {
+      process.env.TARGET_ORG = "test-org";
+      process.env.FAILURE_THRESHOLD = "2";
+      process.env.DRY_RUN = "true";
+      process.env.ISSUE_MENTIONS = "@test";
+      try {
+        await fn();
+      } finally {
+        Object.keys(process.env).forEach((key) => {
+          if (!(key in savedEnv)) delete process.env[key];
+          else process.env[key] = savedEnv[key];
+        });
+      }
+    };
+  }
+
+  it(
+    "reports no alerts when all plugins healthy",
+    withCleanEnv(async () => {
+      const mockGithub = {
+        paginate: {
+          iterator: function* (fn, opts) {
+            yield {
+              data: [{ name: "plugin-a", archived: false, disabled: false }],
+            };
+          },
+        },
+        rest: {
+          repos: { listForOrg: {} },
+          actions: {
+            listWorkflowRunsForRepo: async () => ({
+              data: { workflow_runs: [] },
+            }),
+          },
+        },
+      };
+      const mockCore = {
+        info: () => {},
+        warning: () => {},
+      };
+
+      const result = await runPluginHealthMonitor({
+        github: mockGithub,
+        context: {},
+        core: mockCore,
+      });
+
+      assert.equal(result.alerts.length, 0);
+    })
+  );
+
+  it(
+    "detects plugins exceeding threshold",
+    withCleanEnv(async () => {
+      const mockGithub = {
+        paginate: {
+          iterator: function* () {
+            yield {
+              data: [{ name: "broken-plugin", archived: false, disabled: false }],
+            };
+          },
+        },
+        rest: {
+          repos: { listForOrg: {} },
+          actions: {
+            listWorkflowRunsForRepo: async () => ({
+              data: {
+                workflow_runs: [
+                  { conclusion: "failure", created_at: "2026-03-28T03:00:00Z", html_url: "u1", id: 1, name: "CI" },
+                  { conclusion: "failure", created_at: "2026-03-28T02:00:00Z", html_url: "u2", id: 2, name: "CI" },
+                  { conclusion: "failure", created_at: "2026-03-28T01:00:00Z", html_url: "u3", id: 3, name: "CI" },
+                ],
+              },
+            }),
+          },
+        },
+      };
+      const mockCore = {
+        info: () => {},
+        warning: () => {},
+      };
+
+      const result = await runPluginHealthMonitor({
+        github: mockGithub,
+        context: {},
+        core: mockCore,
+      });
+
+      assert.equal(result.alerts.length, 1);
+      assert.equal(result.alerts[0].repo, "broken-plugin");
+      assert.equal(result.alerts[0].count, 3);
+    })
+  );
+});


### PR DESCRIPTION
## Summary

Daily cron job that monitors all `@ubiquity-os-marketplace` plugins for consecutive `workflow_dispatch` failures. Creates alert issues in the **failing repository** when failures exceed the threshold (default: 10).

Closes #12

## How It Works

```
Cron (daily 06:00 UTC)
  → List all repos in @ubiquity-os-marketplace
  → For each repo: check last 30 workflow_dispatch runs
  → Count consecutive failures from most recent
  → If count >= threshold: create/update alert issue in that repo
```

## Features

- **Cross-repo alerts**: Creates issues in the *failing* plugin repo (requires `CROSS_REPO_TOKEN` secret)
- **Idempotent**: Finds and updates existing alert issues instead of creating duplicates
- **Configurable threshold**: Default 10, adjustable via workflow_dispatch input
- **Dry-run mode**: Test without creating issues
- **Body truncation**: Stays under GitHub's 65,536 char limit (capped at 60K)
- **Proper pagination**: Uses `github.paginate.iterator` for orgs with 100+ repos
- **Input validation**: Guards against NaN/negative/zero threshold values

## Testing — 19/19 pass

```
▶ parseThreshold (7 tests)
  ✔ parses valid integer
  ✔ defaults to 10 for undefined/empty/NaN/zero/negative/Infinity

▶ buildIssueBody (6 tests)
  ✔ includes repo name, failure count, mentions, run links, SHAs
  ✔ truncates body exceeding max length

▶ getConsecutiveFailures (4 tests)
  ✔ returns 0 for empty runs
  ✔ counts consecutive failures from most recent
  ✔ returns 0 when most recent is success
  ✔ handles API errors gracefully

▶ runPluginHealthMonitor (2 tests)
  ✔ reports no alerts when all plugins healthy
  ✔ detects plugins exceeding threshold

19 pass, 0 fail (40ms)
```

Run tests locally: `node --test scripts/plugin-health-monitor.test.mjs`

## Workflow File

> **Note**: The workflow YAML is included below. My GitHub token lacked `workflow` scope to push it directly to `.github/workflows/`. Please add it to `.github/workflows/plugin-health-monitor.yml`:

<details>
<summary>📄 .github/workflows/plugin-health-monitor.yml</summary>

```yaml
name: Plugin Health Monitor

on:
  schedule:
    - cron: "0 6 * * *"
  workflow_dispatch:
    inputs:
      dry_run:
        description: "Only log findings, do not create/update issues"
        type: boolean
        default: false
      failure_threshold:
        description: "Consecutive failures before alerting (default: 10)"
        type: number
        default: 10

permissions:
  issues: write
  actions: read

jobs:
  monitor:
    name: Check Plugin Health
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: 20
      - name: Run Plugin Health Monitor
        uses: actions/github-script@v7
        env:
          TARGET_ORG: ubiquity-os-marketplace
          FAILURE_THRESHOLD: \${{ inputs.failure_threshold || '10' }}
          DRY_RUN: \${{ inputs.dry_run || 'false' }}
          ISSUE_MENTIONS: "@0x4007 @gentlementlegen"
        with:
          github-token: \${{ secrets.CROSS_REPO_TOKEN }}
          script: |
            const { runPluginHealthMonitor } = await import(
              \`\${process.env.GITHUB_WORKSPACE}/scripts/plugin-health-monitor.mjs\`
            );
            await runPluginHealthMonitor({ github, context, core });
```

</details>

## Setup

1. Create a GitHub PAT with `repo` + `workflow` scopes
2. Add it as repository secret `CROSS_REPO_TOKEN`
3. Add the workflow file to `.github/workflows/`
4. The monitor runs daily at 06:00 UTC (or trigger manually)

## Alert Issue Example

When a plugin exceeds the failure threshold, an issue like this is created:

```markdown
## 🚨 Plugin Health Alert

**Repository:** `daemon-pricing`
**Consecutive failures:** 12
**Last checked:** 2026-03-28T06:00:00.000Z

cc @0x4007 @gentlementlegen

### Recent Failed Runs
| # | Workflow | Date | SHA | Link |
|---|---------|------|-----|------|
| 1 | CI | 2026-03-28T03:00:00Z | `abc1234` | [View](...) |
| 2 | CI | 2026-03-27T12:00:00Z | `def5678` | [View](...) |
...
```